### PR TITLE
Cleaning up recompile on execute

### DIFF
--- a/src/Editor.ts
+++ b/src/Editor.ts
@@ -191,14 +191,14 @@ function onExecuteShader(shader: Shader): void {
 }
 
 /** Handles the OK button on the execute shader dialog */
-async function runCurrentShader(performanceTest = false): Promise<FimCanvas | IPerformanceResults> {
+function runCurrentShader(performanceTest = false): FimCanvas | IPerformanceResults {
   let s = currentShader.shader;
   let result: FimCanvas | IPerformanceResults;
 
   let width = $('#execute-shader-width').val() as number;
   let height = $('#execute-shader-height').val() as number;
 
-  await DisposableSet.usingAsync(async disposable => {
+  DisposableSet.using(disposable => {
     let gl = disposable.addDisposable(new FimGLCanvas(width, height));
     let program = disposable.addDisposable(new Program(gl, s));
 
@@ -225,7 +225,7 @@ async function runCurrentShader(performanceTest = false): Promise<FimCanvas | IP
     }
     
     // Recompile the shader as the @const values may have changed
-    await currentShader.compile();
+    program.compileProgram();
 
     if (performanceTest) {
       result = perfTest(currentShader.name, () => program.execute());

--- a/src/Program.ts
+++ b/src/Program.ts
@@ -14,7 +14,7 @@ export class Program extends FimGLProgram {
     super.compileProgram();
   }
 
-  public setConst(name: string, value: number | number[] | boolean | FimGLTexture): void {
+  public setConst(name: string, value: number | number[] | boolean): void {
     this.fragmentShader.consts[name].variableValue = value;
   }
 


### PR DESCRIPTION
This doesn't seem to actually be needed--the code worked previously,
but unnecessarily re-ran the webpack-glsl-minify compiler and created
a second copy of the program, when really we just wanted to call
WebGL's compile.